### PR TITLE
chore(eslint): eslint no-floating-promises error

### DIFF
--- a/packages/eslint-config/eslint-config.js
+++ b/packages/eslint-config/eslint-config.js
@@ -13,6 +13,6 @@ module.exports = {
     rules: {
         '@typescript-eslint/ban-ts-comment': 0,
         '@typescript-eslint/camelcase': 0,
-        '@typescript-eslint/no-floating-promises': 0,
+        '@typescript-eslint/no-floating-promises': "error",
     },
 };


### PR DESCRIPTION
Now requires a parserOptions.project

BREAKING CHANGE: eslint now requires parserOptions.project to be defined