### PR TITLE
feat(eslint-config): Add "prefer Array<T> over T[]" typescript-eslint rule

### DIFF
--- a/packages/eslint-config/eslint-config.js
+++ b/packages/eslint-config/eslint-config.js
@@ -15,5 +15,6 @@ module.exports = {
         '@typescript-eslint/camelcase': 0,
         '@typescript-eslint/no-floating-promises': 'error',
         '@typescript-eslint/no-unused-vars': [ 'error', { 'ignoreRestSiblings': true } ],
+        '@typescript-eslint/array-type': [ 'error', { 'default': 'generic' } ]
     },
 };


### PR DESCRIPTION
Fixes [décision point front](https://www.notion.so/leather-yard-6b5/Le-point-front-Array-et-Crowdin-318d8eca9efb48cba8ebcca4e58f6ecf?pvs=4#37bd758ac1824be1b92126121c61b33a) sur l'utilisation du type `Array<T>` plutôt que `T[]`

#### Don't trust me :
* Rule's documentation : https://typescript-eslint.io/rules/array-type/
* Related playground : https://typescript-eslint.io/play/#ts=5.3.3&fileType=.ts&code=PTAEGEHsCdoUwMYBcBQDIDsDOTQA8AuUAQVgEMBPAHh2gEsMBzAPlAF5QBtAcjO4BpQ3AEbcAugG40mHKApEASnDIATTABsKpaJRpJ6TVhx59BI8VJQhQAUVgxp2XAC8itBo05j2XXgKGikkA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6AQ2mncNqNPRgA2uGw5EXAPbRIAGlFisY7JAAmiAGbsE%2BQZADmiJhMplIC7AF8LAXVHXLQA&tsconfig=&tokens=false