### PR TITLE
feat: add force publish option to lerna cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "packages/*"
   ],
   "scripts": {
-    "release": "lerna publish"
+    "release": "lerna publish --force-publish"
   },
   "devDependencies": {
     "lerna": "^7.4.1"


### PR DESCRIPTION
On a besoin de conserver des numéros de release synchro entre tous les packages, même pour les packages non modifiés.

Car le tagging des releases Git actuel ne mentionne qu'une version, pas de package, ce qui fait qu'on va avoir des problèmes si on release la 5.0.0 du package A, puis 1 mois plus tard la 5.0.0 du package B ... :sweat_smile: 