### PR TITLE
fix: change import of a11y plugin

### DIFF
--- a/src/eslint/rules/react.ts
+++ b/src/eslint/rules/react.ts
@@ -9,6 +9,7 @@ export default [
         files: ['**/*.{js,jsx,mjs,cjs,ts,tsx}'],
         plugins: {
             react: reactPlugin,
+            'jsx-a11y': jsxA11y,
         },
         languageOptions: {
             parserOptions: {
@@ -23,7 +24,9 @@ export default [
     },
     {
         files: ['**/*.{js,mjs,cjs,jsx,mjsx,ts,tsx,mtsx}'],
-        ...jsxA11y.flatConfigs.recommended,
+        rules: {
+            ...jsxA11y.flatConfigs.recommended.rules,
+        },
         languageOptions: {
             ...jsxA11y.flatConfigs.recommended.languageOptions,
             globals: {


### PR DESCRIPTION
On avait cette erreur dans pwapp:
![image](https://github.com/user-attachments/assets/fd687191-1c7c-4815-8a6b-20bd1858bb77)
