### PR TITLE
feat: add dom.iterable lib in TS compiler options

### DIFF
--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "lib": ["dom", "esnext"],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "jsx": "react",
     "allowJs": true,
     "checkJs": false,


### PR DESCRIPTION
#  Proposition : ajout de la lib "dom.iterable" dans la config TypeScript

## Pourquoi ?

J'avais écrit ça dans une PR :

```ts
const [touch] = event.touches;
```

Parce que la règle ESLint m'empêchait d'écrire :

```ts
const touch = event.touches[0];
```

Mais du coup ça pètait une erreur TypeScript au build time :

```ts
Type error: Type 'TouchList' must have a '[Symbol.iterator]()' method that returns an iterator.
```