### PR TITLE
feat: add rule to restrict usage of react-intl in favor of next-intl

### DIFF
--- a/src/eslint/rules/override.ts
+++ b/src/eslint/rules/override.ts
@@ -13,6 +13,18 @@ export default [
             'react/jsx-uses-vars': 'error',
             '@typescript-eslint/no-unsafe-member-access': 'off',
             '@typescript-eslint/no-unsafe-assignment': 'off',
+            'no-restricted-imports': [
+                'warn',
+                {
+                    paths: [
+                        {
+                            name: 'react-intl',
+                            message:
+                                'Please use next-intl instead of react-intl. See official documentation: https://next-intl-docs.vercel.app/ and internal ADR: https://www.notion.so/leather-yard-6b5/ADR-Next-intl-et-internationalisation-d-une-app-Next-17da97006602800bafd9cf4ebdfde508',
+                        },
+                    ],
+                },
+            ],
         },
     },
 ] as const;


### PR DESCRIPTION
Ajout d'une rules ESLINT en warn pour favoriser la migration vers next-intl, en lien avec cet [ADR](https://www.notion.so/leather-yard-6b5/QA-Project-list-page-201a9700660280c98166e1dc198a7fe1)