### PR TITLE
feat: enhance ESLint configuration with import order and directive formatting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,14 +30,25 @@ No test suite is configured in this project.
 
 - Uses `tsup` to build TypeScript source into both ESM and CommonJS formats
 - Source files in `src/eslint/` are built to `eslint/` directory
-- Main entry point: `src/eslint/eslint.config.ts` → `eslint/index.js` + `eslint/index.mjs`
+- Main entry point: `src/eslint/shared.config.ts` → `eslint/index.js` + `eslint/index.mjs`
 
 ### ESLint Configuration Structure
 
-- `src/eslint/eslint.config.ts` - Main ESLint configuration combining all rules
+- `src/eslint/shared.config.ts` - Main ESLint configuration for export to other projects
+- `eslint.config.ts` - Root configuration specific to this repository (overrides `tsconfigRootDir`)
 - `src/eslint/rules/override.ts` - Evaneos-specific rule overrides (includes react-intl deprecation warning)
 - `src/eslint/rules/react.ts` - React-specific linting rules
 - `src/eslint/rules/test.ts` - Testing-specific linting rules
+
+### Local Development Configuration Files
+
+The following files at the repository root are **only for development of this repository** and are **not exported**:
+
+- `tsconfig.json` - TypeScript configuration for this repository (extends `./config/tsconfig.json`)
+- `eslint.config.ts` - ESLint configuration for linting this repository's code
+- `.prettierrc.js` - Prettier configuration for formatting this repository's code
+
+**Important**: When fixing TypeScript errors, ESLint issues, or other development problems in this repository, these are the configuration files to modify, not the exported configurations.
 
 ### Configuration Exports
 
@@ -46,6 +57,14 @@ No test suite is configured in this project.
 - Prettier: Exports config from `prettier/index.js`
 
 ## Important Notes
+
+### Dual ESLint Configuration
+
+This repository uses a unique dual configuration approach:
+- `src/eslint/shared.config.ts` - Clean config exported as a library using `process.cwd()`
+- `eslint.config.ts` - Repository-specific config that imports shared config but overrides `tsconfigRootDir: './'`
+
+This solves the issue where ESLint treats the shared config as the primary config for this repository.
 
 ### Commit Standards
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ module.exports = {
 };
 ```
 
+# Development
+
+## Local Development Files
+
+The following files at the repository root are **only for development experience within this repository** and are **not exported** as part of the package:
+
+- `tsconfig.json` - TypeScript configuration for developing this package
+- `eslint.config.ts` - ESLint configuration for linting this repository's source code
+- `.prettierrc.js` - Prettier configuration for formatting this repository's code
+
+These files are not included in the published package and should not be used as examples for consuming projects.
+
 # Contribution
 
 Contributing to this repo should be simple.

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,4 +1,5 @@
 import globals from 'globals';
+
 import sharedConfig from './src/eslint/shared.config';
 
 export default [
@@ -30,6 +31,7 @@ export default [
         files: config.files || [
             'src/**/*.ts',
             'src/**/*.tsx',
+            'types/**/*.d.ts',
             '.prettierrc.js',
             'prettier/index.js',
             'tsup.config.ts',

--- a/src/eslint/rules/override.ts
+++ b/src/eslint/rules/override.ts
@@ -1,7 +1,11 @@
+import importPlugin from 'eslint-plugin-import';
 import type { Config } from 'typescript-eslint';
 
 export default [
     {
+        plugins: {
+            import: importPlugin,
+        },
         rules: {
             'no-process-env': 'off',
             'prefer-const': 'warn',
@@ -23,6 +27,23 @@ export default [
                             name: 'react-intl',
                             message:
                                 'Use next-intl instead of react-intl.\nADR: https://next-intl-docs.vercel.app/\nADR: https://www.notion.so/leather-yard-6b5/ADR-Next-intl-et-internationalisation-d-une-app-Next-17da97006602800bafd9cf4ebdfde508',
+                        },
+                    ],
+                },
+            ],
+            'import/order': [
+                'warn',
+                {
+                    alphabetize: {
+                        order: 'asc',
+                        caseInsensitive: true,
+                    },
+                    'newlines-between': 'always',
+                    pathGroups: [
+                        {
+                            pattern: '@/**',
+                            group: 'parent',
+                            position: 'before',
                         },
                     ],
                 },

--- a/src/eslint/rules/override.ts
+++ b/src/eslint/rules/override.ts
@@ -48,6 +48,19 @@ export default [
                     ],
                 },
             ],
+            'padding-line-between-statements': [
+                'error',
+                {
+                    blankLine: 'always', // Ligne vide obligatoire après directive
+                    prev: 'directive',
+                    next: '*',
+                },
+                {
+                    blankLine: 'never', // Interdire ligne vide entre directives
+                    prev: 'directive',
+                    next: 'directive',
+                },
+            ],
         },
     },
 ] satisfies Config;

--- a/src/eslint/rules/test.ts
+++ b/src/eslint/rules/test.ts
@@ -1,5 +1,5 @@
-import testingLibrary from 'eslint-plugin-testing-library';
 import pluginJest from 'eslint-plugin-jest';
+import testingLibrary from 'eslint-plugin-testing-library';
 import { Config } from 'typescript-eslint';
 
 export default [

--- a/src/eslint/shared.config.ts
+++ b/src/eslint/shared.config.ts
@@ -1,11 +1,10 @@
-import eslintConfigPrettier from 'eslint-config-prettier';
-
 import eslint from '@eslint/js';
+import eslintConfigPrettier from 'eslint-config-prettier';
 import tseslint from 'typescript-eslint';
 
+import evaneosOverrides from './rules/override';
 import reactLint from './rules/react';
 import testLint from './rules/test';
-import evaneosOverrides from './rules/override';
 
 export default tseslint.config(
     eslint.configs.recommended,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
     "extends": "./config/tsconfig.json",
-    "include": ["src/**/*.ts", "./*.ts", "./commitlint.config.cjs"]
+    "include": ["src/**/*.ts", "./*.ts", "./commitlint.config.cjs", "./types/**/*.d.ts"]
 }

--- a/types/eslint-plugin-import.d.ts
+++ b/types/eslint-plugin-import.d.ts
@@ -1,0 +1,12 @@
+declare module 'eslint-plugin-import' {
+    import type { Linter } from 'eslint';
+
+    interface EslintPluginImport {
+        rules: Record<string, Linter.RuleModule>;
+        configs?: Record<string, Linter.Config>;
+        processors?: Record<string, Linter.Processor>;
+    }
+
+    const plugin: EslintPluginImport;
+    export default plugin;
+}


### PR DESCRIPTION
## Summary

- Add eslint-plugin-import with import order rules for consistent import organization
- Add JavaScript/TypeScript directive formatting rules for consistent code structure
- Update documentation to clarify local development configuration files

## Changes

### Import Organization
- Configure `import/order` rule with alphabetical sorting and consistent spacing
- Force blank lines between import groups for better readability
- Add path groups for custom import patterns (e.g., `@/**` paths)

### Directive Formatting  
- Add `padding-line-between-statements` rule to enforce consistent directive formatting
- Force blank line after directives (`"use strict"`, `"use client"`, `"use server"`)
- Prevent blank lines between consecutive directives to keep them grouped together

### Documentation Improvements
- Add Development section to README explaining local config files are dev-only
- Update CLAUDE.md with detailed dual ESLint configuration explanation
- Document that root config files are not exported and should not be used as examples

## Test Plan

- [x] Build completes without warnings (`npm run build`)
- [x] ESLint runs successfully with new rules
- [x] Import ordering works correctly with alphabetical sorting
- [x] Directive formatting enforces proper spacing (tested with "use client", "use server")
- [x] Documentation accurately reflects repository structure and usage

🤖 Generated with [Claude Code](https://claude.ai/code)