### PR TITLE
feat(eslint): enforce CSS/SCSS imports placement in import/order

### DIFF
--- a/src/eslint/rules/override.ts
+++ b/src/eslint/rules/override.ts
@@ -1,4 +1,5 @@
 import importPlugin from 'eslint-plugin-import';
+
 import type { Config } from 'typescript-eslint';
 
 export default [
@@ -45,7 +46,27 @@ export default [
                             group: 'parent',
                             position: 'before',
                         },
+                        {
+                            pattern: './*.{css,scss,sass,less}',
+                            group: 'object',
+                        },
+                        {
+                            pattern: '**/*.{css,scss,sass,less}',
+                            group: 'object',
+                        },
                     ],
+                    groups: [
+                        'builtin',
+                        'external',
+                        'internal',
+                        'unknown',
+                        'parent',
+                        'sibling',
+                        'index',
+                        'object',
+                        'type',
+                    ],
+                    warnOnUnassignedImports: true,
                 },
             ],
             'padding-line-between-statements': [


### PR DESCRIPTION
## Avant / Après

### 1. `*.module.css` planté dans le tas des composants frères

```diff
 import { useTrackBlockViewed } from '../../../../shared/hooks/useTrackBlockViewed';

 import { AgencyCard } from './AgencyCard/AgencyCard';
 import { AgencyVideoModal } from './AgencyVideoModal/AgencyVideoModal';
-import style from './AgenciesSection.module.css';
+
+import style from './AgenciesSection.module.css';
```

### 2. CSS side-effect coincé au milieu

```diff
 import { PropsWithChildren } from 'react';

-import './base.css';
-
 import { getUserFromServer } from '../../../resources/user/api/pyrite/userServer';
 import { AppRouterPageProviders } from '../../shared/AppRouterPageProviders';
 import { DefaultLayout } from '../../shared/components/DefaultLayout/DefaultLayout';
 import { JsonLdScript } from '../../shared/JsonLdScript';
+
+import './base.css';
```

## Test

Build local injecté dans `node_modules` de `public-website-app` → **300 warnings `import/order`** détectés, `eslint --fix` produit les diffs ci-dessus.