### PR TITLE
ci: publish to npm via trusted publishers (OIDC)

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -5,6 +5,7 @@ on:
 permissions:
     contents: write
     pull-requests: write
+    id-token: write
 
 name: release-please
 
@@ -12,15 +13,15 @@ jobs:
     release-please:
         runs-on: ubuntu-latest
         steps:
-            - uses: googleapis/release-please-action@v4
+            - uses: google-github-actions/release-please-action@v4
               id: release
               with:
                   release-type: node
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               if: ${{ steps.release.outputs.release_created }}
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 20
+                  node-version: 24
                   registry-url: 'https://registry.npmjs.org'
               if: ${{ steps.release.outputs.release_created }}
             - run: npm install
@@ -28,6 +29,4 @@ jobs:
             - run: npm run build
               if: ${{ steps.release.outputs.release_created }}
             - run: npm publish
-              env:
-                  NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
               if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Pourquoi

Le compte npm `evaneos-front` est orphelin (2FA perdu). Aujourd'hui j'ai dû publier `@evaneos/front-config` avec un token perso (7j). [Olivia a déjà migré b2b-ui vers les trusted publishers](https://github.com/Evaneos/b2b-ui/blob/main/.github/workflows/release-please.yaml) — on s'aligne dessus pour ce repo.

[Trusted publishers npm (doc officielle)](https://docs.npmjs.com/trusted-publishers) → publication via OIDC GitHub Actions, sans token long-lived. Bonus : provenance attestation générée automatiquement (repo + package publics).

## Changements workflow

- ajout `id-token: write` (requis OIDC)
- Node `20` → `24` (npm 11.5.1+ requis pour trusted publishing)
- `actions/checkout` `@v4` → `@v6`
- `actions/setup-node` `@v4` → `@v6`
- `googleapis/release-please-action` → `google-github-actions/release-please-action` (renommage du namespace)
- suppression de `NODE_AUTH_TOKEN` sur `npm publish`

## ⚠️ Setup manuel requis AVANT merge

Sur https://www.npmjs.com/package/@evaneos/front-config/access → onglet **Trusted Publishers** :

| Champ | Valeur |
|---|---|
| Publisher | GitHub Actions |
| Organization or user | `Evaneos` |
| Repository | `front-config` |
| Workflow filename | `release-please.yaml` |
| Environment name | _(vide)_ |

Sans ça, le prochain `npm publish` échouera. Le secret `NPM_TOKEN` peut être supprimé après merge & première release réussie.

## Test plan

- [ ] Trusted publisher configuré côté npm
- [ ] Merge → release-please ouvre/met à jour la release PR
- [ ] Merge release PR → publication réussit sans token
- [ ] Vérifier la provenance sur https://www.npmjs.com/package/@evaneos/front-config