### PR TITLE
chore: trigger release 5.4.1 (validate OIDC publish)

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -5,7 +5,7 @@ on:
 permissions:
     contents: write
     pull-requests: write
-    id-token: write
+    id-token: write # required for npm trusted publishing (OIDC)
 
 name: release-please
 


### PR DESCRIPTION
Re-tentative du #94 qui n'a pas pris (commit empty squashé au merge).

Cette fois le commit contient un vrai changement : commentaire `# required for npm trusted publishing (OIDC)` sur la permission `id-token: write` du workflow, et le footer `Release-As: 5.4.1` pour forcer release-please.

## Après merge

1. release-please ouvre la release PR `chore(main): release 5.4.1`
2. Merge cette release PR → publication via OIDC, sans `NPM_TOKEN`
3. Vérifier sur https://www.npmjs.com/package/@evaneos/front-config que 5.4.1 est publiée avec provenance