### PR TITLE
fix: add repository url required for npm provenance

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -5,7 +5,7 @@ on:
 permissions:
     contents: write
     pull-requests: write
-    id-token: write # required for npm trusted publishing (OIDC)
+    id-token: write
 
 name: release-please
 
@@ -13,7 +13,7 @@ jobs:
     release-please:
         runs-on: ubuntu-latest
         steps:
-            - uses: google-github-actions/release-please-action@v4
+            - uses: googleapis/release-please-action@v4
               id: release
               with:
                   release-type: node

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
     "name": "@evaneos/front-config",
     "version": "5.4.1",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Evaneos/front-config.git"
+    },
     "engines": {
         "node": ">=v18",
         "npm": ">=9"


### PR DESCRIPTION
## Problème

Publish 5.4.1 via OIDC trusted publisher → **échec npm 422** :

```
Error verifying sigstore provenance bundle: Failed to validate repository information: 
package.json: 'repository.url' is '', expected to match 
'https://github.com/Evaneos/front-config' from provenance
```

La provenance OIDC a été correctement signée et publiée sur sigstore ([log](https://search.sigstore.dev/?logIndex=1524196658)), mais npm a refusé l'upload du tarball car `package.json` n'a pas de champ `repository` permettant de vérifier que la provenance pointe bien vers ce repo.

## Fix

- ajout `repository` dans package.json (URL `git+https://github.com/Evaneos/front-config.git`)

## Cleanup au passage

- restore `googleapis/release-please-action` (alias `google-github-actions/...` est archivé → warning à chaque run)
- retire un commentaire inutile sur `id-token: write` ajouté dans #95

## Notes

- npm latest est toujours sur 5.4.0 — le tag GitHub v5.4.1 est orphelin (jamais publié). Ce `fix:` va déclencher un bump 5.4.2 (5.4.1 reste un tag GitHub vide, on peut le supprimer manuellement plus tard si tu veux faire propre).
- Le commit `fix:` déclenchera release-please automatiquement après merge.