### PR TITLE
fix(eslint): match deep-relative css imports via matchBase pathGroup

### DIFF
--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     quality-check:
-        name: Run Lint and Prettier
+        name: Run Lint, Prettier and Tests
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
@@ -26,3 +26,6 @@ jobs:
 
             - name: Run Prettier
               run: npm run prettier:check
+
+            - name: Run Tests
+              run: npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,9 @@ This is `@evaneos/front-config`, a shared configuration package for JavaScript/T
 
 ### Testing
 
-No test suite is configured in this project.
+- `npm test` - Build + run tests
+
+Fixture-based tests live under `tests/eslint/` — see the header of `tests/eslint/import-order.test.mjs` for the convention. Run them before touching `src/eslint/rules/*.ts`; CI does the same on every PR.
 
 ## Architecture
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -4,7 +4,12 @@ import sharedConfig from './src/eslint/shared.config';
 
 export default [
     {
-        ignores: ['node_modules/**/*', 'eslint/**/*', 'prettier/**/*'],
+        ignores: [
+            'node_modules/**/*',
+            'eslint/**/*',
+            'prettier/**/*',
+            'tests/eslint/fixtures/**/*',
+        ],
     },
     {
         files: [

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "lint:check": "eslint -c ./eslint.config.ts",
         "lint:fix": "eslint -c ./eslint.config.ts --fix",
         "prettier:check": "prettier --check src/",
-        "prettier:fix": "prettier --write src/"
+        "prettier:fix": "prettier --write src/",
+        "test": "npm run build && find tests -name '*.test.mjs' -exec node --test {} +"
     },
     "devDependencies": {
         "@commitlint/cli": "^19.4.0",

--- a/src/eslint/rules/override.ts
+++ b/src/eslint/rules/override.ts
@@ -47,11 +47,15 @@ export default [
                             position: 'before',
                         },
                         {
-                            pattern: './*.{css,scss,sass,less}',
-                            group: 'object',
-                        },
-                        {
-                            pattern: '**/*.{css,scss,sass,less}',
+                            // matchBase: minimatch's `**/*.{ext}` glob fails to match relative
+                            // paths starting with `..` (minimatch treats `..` as a parent-dir
+                            // reference, not a path segment). matchBase ignores directories and
+                            // matches against the basename, so it catches every `*.css/scss/sass/less`
+                            // regardless of path depth (`./`, `../`, `../../`, bare modules, aliases).
+                            // nocomment is kept to preserve eslint-plugin-import's default behavior
+                            // (patternOptions completely replaces the default `{ nocomment: true }`).
+                            pattern: '*.{css,scss,sass,less}',
+                            patternOptions: { matchBase: true, nocomment: true },
                             group: 'object',
                         },
                     ],
@@ -63,8 +67,8 @@ export default [
                         'parent',
                         'sibling',
                         'index',
-                        'object',
                         'type',
+                        'object',
                     ],
                     warnOnUnassignedImports: true,
                 },

--- a/tests/eslint/fixtures/import-order/css-with-binding-gets-sorted.after.tsx
+++ b/tests/eslint/fixtures/import-order/css-with-binding-gets-sorted.after.tsx
@@ -1,0 +1,6 @@
+// COUNTER-EXAMPLE — CSS imports with a binding ARE sorted by autofix,
+// unlike side-effect imports (see ./incomplete-autofix/).
+
+import alpha from './alpha.module.css';
+import mu from './mu.module.css';
+import zeta from './zeta.module.css';

--- a/tests/eslint/fixtures/import-order/css-with-binding-gets-sorted.before.tsx
+++ b/tests/eslint/fixtures/import-order/css-with-binding-gets-sorted.before.tsx
@@ -1,0 +1,6 @@
+// COUNTER-EXAMPLE — CSS imports with a binding ARE sorted by autofix,
+// unlike side-effect imports (see ./incomplete-autofix/).
+
+import zeta from './zeta.module.css';
+import alpha from './alpha.module.css';
+import mu from './mu.module.css';

--- a/tests/eslint/fixtures/import-order/deep-relative-css-grouped.after.tsx
+++ b/tests/eslint/fixtures/import-order/deep-relative-css-grouped.after.tsx
@@ -1,0 +1,3 @@
+import { foo } from '../../parent/foo';
+
+import '../../../deep/style.css';

--- a/tests/eslint/fixtures/import-order/deep-relative-css-grouped.before.tsx
+++ b/tests/eslint/fixtures/import-order/deep-relative-css-grouped.before.tsx
@@ -1,0 +1,2 @@
+import { foo } from '../../parent/foo';
+import '../../../deep/style.css';

--- a/tests/eslint/fixtures/import-order/external-bare-and-relative-css.valid.tsx
+++ b/tests/eslint/fixtures/import-order/external-bare-and-relative-css.valid.tsx
@@ -1,0 +1,5 @@
+import cx from 'classnames';
+import 'intl-tel-input/build/css/intlTelInput.css';
+import IntlTelInput from 'intl-tel-input/react';
+
+import './InputPhone.module.css';

--- a/tests/eslint/fixtures/import-order/incomplete-autofix/README.md
+++ b/tests/eslint/fixtures/import-order/incomplete-autofix/README.md
@@ -1,0 +1,15 @@
+# Incomplete autofix
+
+`import/order` warns on these side-effect import patterns but the fixer doesn't resolve them — by design: side-effect execution order can be load-bearing (e.g. `reset.css` before `theme.css`, polyfill before consumer code). Reordering automatically could silently break the build. Bindings are sorted normally; see `../css-with-binding-gets-sorted.*`.
+
+| Fixture                          | Unfixed surface                                  |
+|----------------------------------|--------------------------------------------------|
+| `side-effect-stays-put`          | side-effect sandwiched between parent imports    |
+| `side-effect-group-not-sorted`   | a group of side-effects not alphabetized         |
+
+When the rule fires in a consumer project: check by hand whether order matters. If it doesn't, reorder to satisfy the rule. If it does, suppress with an explanatory disable comment:
+
+```ts
+// eslint-disable-next-line import/order -- reset must load before theme
+import 'theme.css';
+```

--- a/tests/eslint/fixtures/import-order/incomplete-autofix/side-effect-group-not-sorted.after.tsx
+++ b/tests/eslint/fixtures/import-order/incomplete-autofix/side-effect-group-not-sorted.after.tsx
@@ -1,0 +1,6 @@
+// LIMITATION — autofix skips side-effect imports. The warning still fires.
+// Reorder by hand, or eslint-disable if order is load-bearing.
+
+import './zeta.css';
+import './alpha.css';
+import './mu.css';

--- a/tests/eslint/fixtures/import-order/incomplete-autofix/side-effect-group-not-sorted.before.tsx
+++ b/tests/eslint/fixtures/import-order/incomplete-autofix/side-effect-group-not-sorted.before.tsx
@@ -1,0 +1,6 @@
+// LIMITATION — autofix skips side-effect imports. The warning still fires.
+// Reorder by hand, or eslint-disable if order is load-bearing.
+
+import './zeta.css';
+import './alpha.css';
+import './mu.css';

--- a/tests/eslint/fixtures/import-order/incomplete-autofix/side-effect-stays-put.after.tsx
+++ b/tests/eslint/fixtures/import-order/incomplete-autofix/side-effect-stays-put.after.tsx
@@ -1,0 +1,8 @@
+// LIMITATION — autofix skips side-effect imports. The warning still fires.
+// Reorder by hand, or eslint-disable if order is load-bearing.
+
+import { A } from '../a';
+
+import '../style.css';
+
+import { B } from '../b';

--- a/tests/eslint/fixtures/import-order/incomplete-autofix/side-effect-stays-put.before.tsx
+++ b/tests/eslint/fixtures/import-order/incomplete-autofix/side-effect-stays-put.before.tsx
@@ -1,0 +1,6 @@
+// LIMITATION — autofix skips side-effect imports. The warning still fires.
+// Reorder by hand, or eslint-disable if order is load-bearing.
+
+import { A } from '../a';
+import '../style.css';
+import { B } from '../b';

--- a/tests/eslint/fixtures/import-order/missing-newline-between-parent-and-styles.after.tsx
+++ b/tests/eslint/fixtures/import-order/missing-newline-between-parent-and-styles.after.tsx
@@ -1,0 +1,3 @@
+import { useState } from 'react';
+
+import './Component.css';

--- a/tests/eslint/fixtures/import-order/missing-newline-between-parent-and-styles.before.tsx
+++ b/tests/eslint/fixtures/import-order/missing-newline-between-parent-and-styles.before.tsx
@@ -1,0 +1,2 @@
+import { useState } from 'react';
+import './Component.css';

--- a/tests/eslint/fixtures/import-order/sibling-and-parent-css-as-one-block.valid.tsx
+++ b/tests/eslint/fixtures/import-order/sibling-and-parent-css-as-one-block.valid.tsx
@@ -1,0 +1,4 @@
+import { foo } from '../parent';
+
+import './sibling.css';
+import '../parent.css';

--- a/tests/eslint/fixtures/import-order/target-layout.valid.tsx
+++ b/tests/eslint/fixtures/import-order/target-layout.valid.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import { Locale } from '../core/Locale';
+import { Provider } from '../shared/Provider';
+
+import type { Preview } from '@storybook/nextjs';
+
+import './local.css';
+import '../app/base.css';
+import '../styles/animation.css';

--- a/tests/eslint/fixtures/import-order/types-positioned-before-styles.valid.tsx
+++ b/tests/eslint/fixtures/import-order/types-positioned-before-styles.valid.tsx
@@ -1,0 +1,7 @@
+import { Component } from 'react';
+
+import { Service } from '../services/Service';
+
+import type { Props } from '../types/Props';
+
+import './Widget.css';

--- a/tests/eslint/import-order.test.mjs
+++ b/tests/eslint/import-order.test.mjs
@@ -1,0 +1,173 @@
+// Fixture-based tests for the import/order rule shipped by this package.
+//
+// Layout:
+//   tests/eslint/fixtures/<category>/<scenario>.<type>.tsx
+//
+// The category subfolder groups tests by intent (currently only
+// `import-order/`; add a sibling category if you start testing another
+// rule). Within a category, the file suffix determines the test type:
+//
+//   - <name>.valid.tsx              → "this code is already lint-clean".
+//                                     Asserts 0 import/order warnings AND
+//                                     that autofix doesn't touch it.
+//
+//   - <name>.before.tsx + .after.tsx → "autofix transforms before into
+//                                      after". Asserts `eslint --fix` on
+//                                      <name>.before.tsx yields exactly
+//                                      <name>.after.tsx.
+//
+// Adding a case = drop a file (or pair) in the category folder. No code
+// change to this runner.
+//
+// Notes:
+//
+// - Known autofix limitations are NOT swept under the rug — they live in
+//   `fixtures/import-order/incomplete-autofix/`, each as a `.before/.after`
+//   pair plus a leading comment block in the file explaining the
+//   limitation. See that folder's README.md for the index. The fixtures
+//   double as regression alarms: if a future bump of
+//   `eslint-plugin-import` removes a limitation, the matching test fails.
+//
+// - Comments at the top of `.before.tsx` survive autofix unchanged, so
+//   they end up identical in `.after.tsx`. Use them to explain the case
+//   to whoever reads the fixture.
+
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { ESLint } from 'eslint';
+import importPlugin from 'eslint-plugin-import';
+import tseslint from 'typescript-eslint';
+
+import sharedConfig from '../../eslint/index.mjs';
+
+const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+
+const importOrderConfigBlock = sharedConfig.find(
+    (block) => block?.rules && block.rules['import/order'],
+);
+if (!importOrderConfigBlock) {
+    throw new Error('Could not locate import/order rule config in built shared config.');
+}
+
+const isolatedConfig = [
+    {
+        files: ['**/*.{ts,tsx,js,jsx,mjs,cjs}'],
+        languageOptions: {
+            ecmaVersion: 2022,
+            sourceType: 'module',
+            parser: tseslint.parser,
+        },
+        plugins: { import: importPlugin },
+        rules: { 'import/order': importOrderConfigBlock.rules['import/order'] },
+    },
+];
+
+const eslintFixer = new ESLint({
+    overrideConfigFile: true,
+    overrideConfig: isolatedConfig,
+    fix: true,
+});
+
+async function runEslintFix(code) {
+    const [result] = await eslintFixer.lintText(code, { filePath: 'fixture.tsx' });
+    return {
+        output: result.output ?? code,
+        importOrderWarnings: result.messages.filter((m) => m.ruleId === 'import/order'),
+    };
+}
+
+function listFixtureFiles(rootDir) {
+    const result = [];
+    function walk(dir) {
+        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+            const full = join(dir, entry.name);
+            if (entry.isDirectory()) walk(full);
+            else if (entry.isFile() && entry.name.endsWith('.tsx')) result.push(full);
+        }
+    }
+    walk(rootDir);
+    return result;
+}
+
+const allFiles = listFixtureFiles(FIXTURES_DIR);
+
+const validFiles = allFiles.filter((p) => p.endsWith('.valid.tsx'));
+const beforeFiles = allFiles.filter((p) => p.endsWith('.before.tsx'));
+const afterFiles = new Set(allFiles.filter((p) => p.endsWith('.after.tsx')));
+
+for (const validFile of validFiles) {
+    const id = relative(FIXTURES_DIR, validFile).replace(/\.valid\.tsx$/, '');
+    test(`fixture: ${id} — already lint-clean (autofix is a no-op)`, async () => {
+        const code = readFileSync(validFile, 'utf8');
+        const { output, importOrderWarnings } = await runEslintFix(code);
+
+        assert.equal(
+            importOrderWarnings.length,
+            0,
+            `${id}.valid.tsx must trigger no import/order warnings. Got: ${JSON.stringify(
+                importOrderWarnings.map((m) => m.message),
+                null,
+                2,
+            )}`,
+        );
+        assert.equal(output, code, `autofix must not modify ${id}.valid.tsx`);
+    });
+}
+
+for (const beforeFile of beforeFiles) {
+    const afterFile = beforeFile.replace(/\.before\.tsx$/, '.after.tsx');
+    if (!existsSync(afterFile) || !afterFiles.has(afterFile)) {
+        throw new Error(
+            `Fixture mismatch: ${relative(FIXTURES_DIR, beforeFile)} has no matching .after.tsx`,
+        );
+    }
+    const id = relative(FIXTURES_DIR, beforeFile).replace(/\.before\.tsx$/, '');
+
+    test(`fixture: ${id} — autofix turns .before.tsx into .after.tsx`, async () => {
+        const before = readFileSync(beforeFile, 'utf8');
+        const after = readFileSync(afterFile, 'utf8');
+        const { output } = await runEslintFix(before);
+
+        assert.equal(output, after, `autofixed ${id}.before.tsx does not match ${id}.after.tsx`);
+    });
+}
+
+// Sanity check: every .after.tsx must have a matching .before.tsx.
+for (const afterFile of afterFiles) {
+    const beforeFile = afterFile.replace(/\.after\.tsx$/, '.before.tsx');
+    if (!existsSync(beforeFile)) {
+        throw new Error(
+            `Fixture mismatch: ${relative(FIXTURES_DIR, afterFile)} has no matching .before.tsx`,
+        );
+    }
+}
+
+test('import/order — options have the documented shape', () => {
+    const [, importOrderOptions] = importOrderConfigBlock.rules['import/order'];
+
+    assert.equal(importOrderOptions.alphabetize?.order, 'asc');
+    assert.equal(importOrderOptions['newlines-between'], 'always');
+    assert.equal(importOrderOptions.warnOnUnassignedImports, true);
+
+    const cssPathGroup = importOrderOptions.pathGroups.find(
+        (g) => g.pattern === '*.{css,scss,sass,less}',
+    );
+    assert.ok(cssPathGroup, 'matchBase CSS pathGroup is registered');
+    assert.equal(cssPathGroup.group, 'object');
+    assert.equal(
+        cssPathGroup.patternOptions?.matchBase,
+        true,
+        'matchBase option is enabled so the pattern catches every CSS depth',
+    );
+
+    const typeIdx = importOrderOptions.groups.indexOf('type');
+    const objectIdx = importOrderOptions.groups.indexOf('object');
+    assert.ok(
+        typeIdx >= 0 && objectIdx >= 0 && typeIdx < objectIdx,
+        'type group must come before object group so type imports sit above the CSS block',
+    );
+});


### PR DESCRIPTION
## Context

Bug introduced in 5.4.0 with the new `enforce CSS/SCSS imports placement in import/order` rule.

## Root cause

The pathGroups patterns used to classify css imports into the `object` group:

```js
{ pattern: './*.{css,scss,sass,less}', group: 'object' },
{ pattern: '**/*.{css,scss,sass,less}', group: 'object' }
```

…silently failed to match any relative path containing `..` because minimatch treats `..` as a parent-dir reference, not a path segment. Empirical demo:

```js
minimatch('../foo.css',           '**/*.{css,scss,sass,less}'); // false
minimatch('../../foo.css',        '**/*.{css,scss,sass,less}'); // false
minimatch('./foo.css',            '**/*.{css,scss,sass,less}'); // false
minimatch('intl-tel-input/x.css', '**/*.{css,scss,sass,less}'); // true (only bare)
```

Consequence: every relative css import in consumer projects (`./foo.css`, `../app/base.css`, `../../shared/styles.css`, etc.) leaked into its natural `parent` group and got alphabetically intermixed with sibling js/ts imports. The group separation the rule was meant to enforce never actually happened for the common case.

## Fix

**1.** Replace the two broken patterns with a single matchBase-based pattern:

```diff
-{ pattern: './*.{css,scss,sass,less}', group: 'object' },
-{ pattern: '**/*.{css,scss,sass,less}', group: 'object' }
+{
+    pattern: '*.{css,scss,sass,less}',
+    patternOptions: { matchBase: true, nocomment: true },
+    group: 'object',
+}
```

`matchBase: true` makes minimatch ignore directories and match against the basename alone, so the pattern catches every `.css/scss/sass/less` regardless of depth or prefix (`./`, `../`, `../../`, bare modules, aliases like `@/` or `~/`, absolute `/`). `nocomment: true` is kept to preserve the rule's default behavior since `patternOptions` completely replaces the default `{ nocomment: true }`.

**2.** Swap `type` and `object` in `groups` so types appear just above the css block:

```diff
 groups: [
   'builtin', 'external', 'internal', 'unknown',
   'parent', 'sibling', 'index',
-  'object',
   'type',
+  'object',
 ],
```

Css imports (now reliably in `object`) belong visually at the very bottom of the import block; type-only imports belong with the code dependencies they describe.

## Resulting layout

```ts
import React from 'react';

import { foo } from '../core/foo';

import type { Foo } from '../core/foo';

import './component.module.css';
```

## Tests

Added `tests/eslint/import-order.test.mjs` using Node's built-in test runner + ESLint `RuleTester`. Covers:

- The target layout (parent → type → css) passes with 0 warnings
- Sibling (`./`) and parent (`../`) css live in the same `object` block
- Deep-relative css (`../../../foo.css`) is classified as `object` (the regression that this PR fixes — would have failed before)
- Css sandwiched between parent imports is flagged
- Type import appearing after the css group is flagged
- Shape assertions on the rule options (matchBase, type-before-object)

Test script added to `package.json`: `npm test` builds the package then runs `node --test` against the built artifact.

## Validation in consumer

Validated end-to-end on `public-website-app` (~180 files reorganized). After this fix:

- `eslint --fix` global converges with 5 residual warnings in 3 files (vs ~15 unfixable warnings + 1 error before).
- The 5 residuals are not a regression of this fix — they're the known incomplete-autofix bug of `eslint-plugin-import` (rule detects the issue but autofixer makes local-only swaps and gets stuck). Easy manual fixup.
- `npm run static-code-analysis` exit 0.

## Versioning

`fix:` → patch bump (5.4.2 → 5.4.3) via release-please.