### PR TITLE
chore(security): refresh .npmrc before= date to 2026-08-11 (INC-227)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,4 +2,4 @@
 # Refuse to install packages published in the last 7 days, leaving time for
 # the community to detect and unpublish compromised versions.
 # To upgrade dependencies, bump this date to no later than today - 7 days.
-before=2026-05-04
+before=2026-08-11


### PR DESCRIPTION
## What changes

One line in `.npmrc`:

```diff
-before=2026-05-04
+before=2026-08-11
```

`package-lock.json` is deliberately **not** regenerated — see below.

## Why

The `before=` pin refuses to install any package published in the last 7 days, so a compromised release has time to be detected and unpublished (INC-227). It only works if the date moves forward; left alone, it becomes a ceiling.

`README.md:130-132` states the rule: *"If you need to upgrade dependencies, update the `before` date in `.npmrc` to a value at most today minus 7 days."* The date had been sitting at 2026-05-04 since May — over three months stale, silently capping **every** dependency update of this repo to a pre-May version. 2026-08-11 is today minus 7, the maximum the rule allows.

Spotted while bumping `eslint-plugin-testing-library` (#101) and deliberately kept out of that PR: mixing the two would have pulled unrelated bumps into a review about one plugin.

> [!NOTE]
> **Nothing is upgraded here.** Raising the ceiling does not itself move any dependency: `npm install` was not run and the lockfile is untouched, so CI (`npm ci`) resolves exactly what it resolved before. What changes is that the *next* dependency update is no longer capped at May.

## Verification

`npm run build`, `npm run lint:check`, `npm run prettier:check` and `npm test` all exit 0, and `git status` shows `.npmrc` as the only modified file.
