### PR TITLE
docs: correct the commit-language and release facts in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ This solves the issue where ESLint treats the shared config as the primary confi
 
 - Uses conventional commits with custom types defined in `commitlint.config.cjs`
 - Supported types: feat, fix, docs, chore, style, refactor, ci, test, revert, fix!, feat!, other
-- Commit messages are validated in French
+- Commit messages are written in English; the French failure messages come from `commitlint.config.cjs`'s own `function-rules`, and say nothing about the language a commit should be written in
 
 ### Custom Rules
 
@@ -82,5 +82,7 @@ This solves the issue where ESLint treats the shared config as the primary confi
 
 ### Release Process
 
-- Automated release PRs are created after merging changes
-- Uses semantic versioning and conventional commits for release automation
+- Merging to `main` runs release-please, which opens a release PR; merging **that** PR is what publishes to npm
+- `feat` cuts a minor, `fix` a patch, `feat!`/`fix!` a major. No other type is user facing on its own: release-please skips them, logging `No user facing commits found ... - skipping`, and nothing reaches npm
+- A `Release-As: X.Y.Z` footer forces a release whatever the type — that is how 5.4.1 shipped a `ci:`-only change
+- Which commits release-please reads depends on how the PR is merged, and this repo allows all three strategies: a squash merge collapses the branch into the PR **title**, so that title's type is the only one that counts; a merge commit keeps the individual types


### PR DESCRIPTION
## Why

Two statements in `CLAUDE.md` were wrong or ambiguous enough to mislead a reader — and one of them just cost a release.

#101 (the `eslint-plugin-testing-library` v7 bump) was titled `chore(deps):` on the strength of *"Automated release PRs are created after merging changes"*. It was squash-merged, release-please read that title, found no user facing commit, and opened nothing:

```
✔ No user facing commits found since c7e8cb3be5e0326d4b911fd68e86bc1435ab96f6 - skipping
```

The fix is on `main` but no published version carries it. #102 unblocks that; this PR stops the next person from repeating it.

## What changes

**Commit Standards** — *"Commit messages are validated in French"* actually described commitlint's own French failure strings, but reads as a rule about the language commits should be written in. The history is English (151 of 152 commit messages). The line now says which is which.

**Release Process** — the two bullets said only that release PRs "are created after merging changes". They now state what actually gates a release:

- which types cut which bump — `feat` minor, `fix` patch, `feat!`/`fix!` major — and that every other type is skipped with nothing reaching npm;
- the `Release-As: X.Y.Z` footer that overrides this, which is how 5.4.1 shipped a `ci:`-only change;
- that the merge strategy decides which commits release-please even sees. This repo allows all three (`allow_squash_merge`, `allow_merge_commit`, `allow_rebase_merge` are all true, no ruleset, `required_linear_history: false`), and the history mixes them — 40 merge commits up to #90, squashes since. Under a squash the PR **title** is the only type that counts; under a merge commit the individual types are read.

> [!NOTE]
> **Docs only.** No code, no config, no behaviour change — and `docs:` is itself not a releasing type, so merging this publishes nothing.

## Verification

Every claim above was checked against the repo, `CHANGELOG.md`, `commitlint.config.cjs`, the GitHub repository settings and the release-please Actions logs — not inferred from the previous wording.
