### PR TITLE
docs: trim CLAUDE.md of what the README already says

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,37 +36,17 @@ Fixture-based tests live under `tests/eslint/` — see the header of `tests/esli
 
 ### ESLint Configuration Structure
 
-- `src/eslint/shared.config.ts` - Main ESLint configuration for export to other projects
-- `eslint.config.ts` - Root configuration specific to this repository (overrides `tsconfigRootDir`)
+- `src/eslint/shared.config.ts` - Main ESLint configuration for export to other projects; resolves types via `process.cwd()`
+- `eslint.config.ts` - Root configuration for this repository: imports the shared config but overrides `tsconfigRootDir: './'`. Both are needed — without the override, ESLint treats the shared config as this repository's own primary config
 - `src/eslint/rules/override.ts` - Evaneos-specific rule overrides (includes react-intl deprecation warning)
 - `src/eslint/rules/react.ts` - React-specific linting rules
 - `src/eslint/rules/test.ts` - Testing-specific linting rules
 
 ### Local Development Configuration Files
 
-The following files at the repository root are **only for development of this repository** and are **not exported**:
-
-- `tsconfig.json` - TypeScript configuration for this repository (extends `./config/tsconfig.json`)
-- `eslint.config.ts` - ESLint configuration for linting this repository's code
-- `.prettierrc.js` - Prettier configuration for formatting this repository's code
-
-**Important**: When fixing TypeScript errors, ESLint issues, or other development problems in this repository, these are the configuration files to modify, not the exported configurations.
-
-### Configuration Exports
-
-- ESLint: Exports flat config array from `eslint/index.js|mjs`
-- TypeScript: Exports base config from `config/tsconfig.json`
-- Prettier: Exports config from `prettier/index.js`
+`tsconfig.json`, `eslint.config.ts` and `.prettierrc.js` at the root configure **this repository only** and are not exported. When fixing a TypeScript error, an ESLint issue or any other development problem here, modify those — never the exported configurations.
 
 ## Important Notes
-
-### Dual ESLint Configuration
-
-This repository uses a unique dual configuration approach:
-- `src/eslint/shared.config.ts` - Clean config exported as a library using `process.cwd()`
-- `eslint.config.ts` - Repository-specific config that imports shared config but overrides `tsconfigRootDir: './'`
-
-This solves the issue where ESLint treats the shared config as the primary config for this repository.
 
 ### Commit Standards
 
@@ -77,7 +57,7 @@ This solves the issue where ESLint treats the shared config as the primary confi
 ### Custom Rules
 
 - Warns against using `react-intl` (deprecated in favor of `next-intl`)
-- Disables strict TypeScript safety rules for easier migration
+- Turns off exactly two type-safety rules — `@typescript-eslint/no-unsafe-member-access` and `no-unsafe-assignment`; `recommendedTypeChecked` and `strict` stay on
 - React components don't require explicit React import (JSX transform)
 
 ### Release Process


### PR DESCRIPTION
## Why

`CLAUDE.md` is loaded into context on every agent session in this repo, so anything it says that the `README.md` already says is paid for twice, and anything it overstates is acted on as written. A cold read of the file — judged as a standalone text, without knowledge of how it was written — surfaced five such statements. Each was checked against the repo before being touched, and this PR removes 24 lines while adding 4.

## What changes

**Two sections were restating the README.** `README.md:110-118` ("Local Development Files") already lists the same three root files with the same bolded *"only for development … not exported"* warning, and `README.md:13-106` documents the three consumer entry points with working import snippets. What `CLAUDE.md` alone carried was the *directive* — when fixing a problem here, edit those files, not the exported configs — so the directive stays as one sentence and the duplicated reference goes.

**One pair of files was described twice.** `src/eslint/shared.config.ts` and `eslint.config.ts` appeared both in "ESLint Configuration Structure" and in "Dual ESLint Configuration", each time stating the `tsconfigRootDir` override. Merged into a single description.

> [!NOTE]
> The merge deliberately **keeps** the reason the override exists — without it, ESLint treats the shared config as this repository's own primary config. That sentence looks like historical rationale but describes a live constraint: it is what stops a future contributor from collapsing the two configs.

**One bullet overstated the code.** *"Disables strict TypeScript safety rules for easier migration"* reads as a broad relaxation. `src/eslint/rules/override.ts` turns off exactly two rules — `@typescript-eslint/no-unsafe-member-access` and `no-unsafe-assignment` — while `shared.config.ts` keeps `recommendedTypeChecked` and `config/tsconfig.json` keeps `"strict": true`. In a package whose entire subject is which rules are on, that gap matters. The bullet now names the two rules and says what stays on. The "migration" it invoked has no antecedent anywhere: `grep -rni "migration\|migrate"` over the repo returned that line and nothing else.

## What was deliberately left alone

Several other candidates were raised and dropped after checking: the `react-intl` mention appears twice but the two carry different facts (*where* the rule lives, *what* replaces it); the note that CI runs the tests on every PR has a technical exception for non-`main` base branches that never occurs here; and the file's opening line is boilerplate but costs nothing.

## Verification

`npm run build`, `npm run lint:check`, `npm run prettier:check` and `npm test` (21/21) all exit 0. Docs only — no code, no config, and `docs:` is not a releasing type, so merging this publishes nothing.
